### PR TITLE
Remove builder label from OpenCode review workflow

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -8,7 +8,7 @@ jobs:
   review:
     name: AI Code Review
     if: github.event.pull_request.draft == false
-    runs-on: [self-hosted, builder]
+    runs-on: self-hosted
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary
- change OpenCode PR review workflow to run on  only
- remove  label requirement to match current runner labels